### PR TITLE
Fix NoMethodError: `min_wait` in RetryOn429

### DIFF
--- a/lib/shopify_api_mixins/retry_on429.rb
+++ b/lib/shopify_api_mixins/retry_on429.rb
@@ -20,7 +20,7 @@ module ShopifyApiMixins
           case code = e.response.code.to_i
           when 429
             wait_time = e.response['Retry-After'].to_i
-            wait_time = min_wait if wait_time < RetryOn429.min_wait
+            wait_time = RetryOn429.min_wait if wait_time < RetryOn429.min_wait
             Rails.logger.info "Got a 429, will retry in #{wait_time} seconds"
             sleep(wait_time)
             next


### PR DESCRIPTION
Fix NoMethodError: `min_wait` in RetryOn429